### PR TITLE
Fix how Eager app brings in jQuery

### DIFF
--- a/install.js
+++ b/install.js
@@ -1,39 +1,12 @@
-/* 
+/*
 This file is, together with install.json, the configuration for eager.io,
 which allows testing the library on webpages.
 It is not necessary for running birdman.js
 */
-(function(){
-  // First of all, let's load jQuery
-  if(typeof(jQuery) == 'undefined') {
-    window.jQuery = 'loading';
-    var jq = document.createElement('script');
-    jq.type = 'text/javascript';
-    jq.src = '//ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js';
-    jq.onload = function() {
-      // JQuery is loaded...
-      console.log('jQuery ' + jQuery.fn.jquery + ' loaded successfully.');
-      // Now load the actual script (which requires $)
-      $.getScript('https://cdn.rawgit.com/chrisma/birdman.js/v1.0.0/birdman.js')
-        .done(function( script, textStatus ) {
-          console.log('Birdman.js loaded successfully.');
-          console.log(INSTALL_OPTIONS.advanced);
-          $(INSTALL_OPTIONS.location).birdman({
-            'delay': parseInt(INSTALL_OPTIONS.advanced.delay),
-            'speedUp': INSTALL_OPTIONS.speedUp
-          });
-      })
-    };
-    jq.onerror = function () {
-        delete jQuery;
-        console.error('Error while loading jQuery!');
-    };
-    document.getElementsByTagName('head')[0].appendChild(jq);
-  } else {
-    if (typeof (jQuery) == 'function') {
-        console.log('jQuery (' + jQuery.fn.jquery + ') is already loaded!');
-    } else {
-        console.log('jQuery is already loading...');
-    }
-  }
-})();
+
+window.EagerBirdman = function(options){
+  jQuery(options.location).birdman({
+    'delay': parseInt(options.advanced.delay),
+    'speedUp': options.speedUp
+  });
+}

--- a/install.json
+++ b/install.json
@@ -3,9 +3,31 @@
     "body": [
       {
         "type": "script",
-        "src": "install.js"
+        "src": "birdman.js",
+        "moduleType": "global",
+        "exports": [
+          "jQuery"
+        ],
+        "depends": {
+          "github.com/jquery/jquery:jquery.js": "jQuery"
+        }
+      },
+      {
+        "type": "script",
+        "src": "install.js",
+        "moduleType": "global",
+        "depends": {
+          "github.com/jquery/jquery:jquery.js": "jQuery"
+        }
+      },
+      {
+        "type": "script",
+        "contents": "EagerBirdman(INSTALL_OPTIONS)"
       }
     ]
+  },
+  "dependencies": {
+    "github.com/jquery/jquery": ">= 1.7.0, <= 1.10.2"
   },
   "options": {
     "properties": {
@@ -32,9 +54,9 @@
               "600"
             ],
             "enumNames": {
-              "150": "fast",
-              "300": "normal",
-              "600": "slow"
+              "150": "Fast",
+              "300": "Normal",
+              "600": "Slow"
             },
             "default": "300"
           },


### PR DESCRIPTION
Including jQuery externally would potentially result in different apps all bringing in their own copy of jQuery.  Eager can automatically bundle in jQuery such that it doesn't interfere with any other files on the site.
